### PR TITLE
Avoid sending request when no file was selected

### DIFF
--- a/src/directives/uploadButton.js
+++ b/src/directives/uploadButton.js
@@ -28,6 +28,11 @@ angular.module('lr.upload.directives').directive('uploadButton', function(upload
 
       var fileInput = angular.element('<input type="file" />');
       fileInput.on('change', function uploadButtonFileInputChange() {
+
+        if (fileInput[0].files.length == 0) {
+          return;
+        }
+
         if (!scope.options) {
           scope.options = {};
         }


### PR DESCRIPTION
When the user pressed ESC in the file selection dialog, the request is incorrectly issued.

If both #7 and this one are accepted, then this should go after having called onBegin in order to allow to clear upload indications in the UI.
