### PR TITLE
Fix readme and jshint tips so that the demo works on first try

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -212,6 +212,6 @@ module.exports = function (grunt) {
   grunt.registerTask('release', [
     'package',
     'bump'
-  ])
+  ]);
 
 };

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ brew install nodejs
 ```
 then
 ```sh
-npm install -g grunt-cli karma
+npm install -g grunt-cli karma express
 ```
 then from within angular-upload
 ```sh
@@ -120,7 +120,7 @@ npm install && bower install
 ```
 then you can start the testserver up with
 ```sh
-grunt server
+grunt webserver
 ```
 
 and you can access it through http://localhost:9001 and test the uploader

--- a/src/directives/uploadButton.js
+++ b/src/directives/uploadButton.js
@@ -29,7 +29,7 @@ angular.module('lr.upload.directives').directive('uploadButton', function(upload
       var fileInput = angular.element('<input type="file" />');
       fileInput.on('change', function uploadButtonFileInputChange() {
 
-        if (fileInput[0].files.length == 0) {
+        if (fileInput[0].files.length === 0) {
           return;
         }
 


### PR DESCRIPTION
A few changes to make the demo work right out of the box:
- Readme: should run `grunt webserver` (no `server` task)
- Readme: add a brief mention to install **express** globally, along with grunt-cli and karma
- fix issues found by jshint when running grunt webserver
