### PR TITLE
fix a iframeUpload bug

### DIFF
--- a/src/directives/uploadButton.js
+++ b/src/directives/uploadButton.js
@@ -22,7 +22,7 @@ angular.module('lr.upload.directives').directive('uploadButton', function(upload
       fileInput.on('change', function uploadButtonFileInputChange() {
 
         // without this, iframeUpload always upload the first time picked file
-        var fileInput = $(this);
+        var fileInput = angular.element(this);
 
         if (fileInput[0].files && fileInput[0].files.length === 0) {
           return;

--- a/src/directives/uploadButton.js
+++ b/src/directives/uploadButton.js
@@ -21,6 +21,9 @@ angular.module('lr.upload.directives').directive('uploadButton', function(upload
 
       fileInput.on('change', function uploadButtonFileInputChange() {
 
+        // without this, iframeUpload always upload the first time picked file
+        var fileInput = $(this);
+
         if (fileInput[0].files && fileInput[0].files.length === 0) {
           return;
         }


### PR DESCRIPTION
This bug make iframeUpload always upload the first time picked file, for example: 
You open the page in a browser only support iframe upload,
first time, you want to upload 'tree.jpg', so you pick it, then 'tree.jpg' upload automatically, it's good;
after that, you want to upload 'flower.jpg', so you pick it, but the bug make 'tree.jpg' upload again. (actually you couldn't upload any other file without refresh)

Reason:
iframeUpload clone and replace the input file element with a new one, but when `change` event trigger, the `fileInput` in callback is point to the old one.