### PR TITLE
allow uploading same file twice

### DIFF
--- a/src/formDataUpload.js
+++ b/src/formDataUpload.js
@@ -19,6 +19,7 @@ angular.module('lr.upload.formdata', [])
             angular.forEach(el.files, function (file) {
               files.push(file);
             });
+            el.value = '';
           });
 
           // Do we have any files?


### PR DESCRIPTION
The input field needs to be cleared to allow selecting and uploading the same file again. I've formed the suggestion from https://github.com/leon/angular-upload/issues/26 into a pull request. Could you review it?