### PR TITLE
Add missing css so that wiredep can also pick up.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,10 @@
   "description": "AngularJS Upload, Handle your uploading with style",
   "version": "1.0.12",
   "author": "Leon Radley<leon@radley.se>",
-  "main": "angular-upload.js",
+  "main": [
+    "angular-upload.js",
+    ""src/directives/btnUpload.min.css"
+  ],
   "dependencies": {
     "angular": ">=1.0.8"
   },


### PR DESCRIPTION
When user includes angular-upload in his bower.json, and if wiredep is used, wiredep doesn't pick up the css file to be included in the build.  So the user ends up manually adding a override section in his bower.json to include both the js and css file.

The button looks broken with the css and it's not obvious what is wrong for those who use the angular generator for manage the build and etc.